### PR TITLE
api client 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
 	},
 	"packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631",
 	"msw": {
-		"workerDirectory": [
-			"public"
-		]
+		"workerDirectory": ["public"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"dependencies": {
 		"@tanstack/react-query": "^5.45.0",
 		"@tanstack/react-router": "^1.38.1",
+		"axios": "^1.7.2",
 		"clsx": "^2.1.1",
 		"jotai": "^2.8.3",
 		"react": "19.0.0-beta-26f2496093-20240514",
@@ -36,6 +37,8 @@
 	},
 	"packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631",
 	"msw": {
-		"workerDirectory": ["public"]
+		"workerDirectory": [
+			"public"
+		]
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.38.1
         version: 1.38.1(react-dom@19.0.0-beta-26f2496093-20240514(react@19.0.0-beta-26f2496093-20240514))(react@19.0.0-beta-26f2496093-20240514)
+      axios:
+        specifier: ^1.7.2
+        version: 1.7.2
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -793,12 +796,18 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.19:
     resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axios@1.7.2:
+    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -875,6 +884,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -919,6 +932,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -975,9 +992,22 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.2.1:
     resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
     engines: {node: '>=14'}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1144,6 +1174,14 @@ packages:
     resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@9.0.4:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1288,6 +1326,9 @@ packages:
     resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2259,6 +2300,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.19(postcss@8.4.38):
     dependencies:
       browserslist: 4.23.1
@@ -2268,6 +2311,14 @@ snapshots:
       picocolors: 1.0.1
       postcss: 8.4.38
       postcss-value-parser: 4.2.0
+
+  axios@1.7.2:
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@1.0.2: {}
 
@@ -2343,6 +2394,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   convert-source-map@2.0.0: {}
@@ -2375,6 +2430,8 @@ snapshots:
   debug@4.3.5:
     dependencies:
       ms: 2.1.2
+
+  delayed-stream@1.0.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -2447,10 +2504,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  follow-redirects@1.15.6: {}
+
   foreground-child@3.2.1:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  form-data@4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -2573,6 +2638,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@9.0.4:
     dependencies:
@@ -2701,6 +2772,8 @@ snapshots:
       source-map-js: 1.2.0
 
   prettier@3.3.2: {}
+
+  proxy-from-env@1.1.0: {}
 
   queue-microtask@1.2.3: {}
 

--- a/src/api/axios-client/index.ts
+++ b/src/api/axios-client/index.ts
@@ -1,0 +1,82 @@
+import axios, {
+	type AxiosInstance,
+	type AxiosRequestConfig,
+	type AxiosResponse,
+} from "axios";
+
+import {
+	HttpClient,
+	type HttpRequestConfig,
+	type HttpResponse,
+} from "../http-client";
+import { HttpError } from "../http-client/error";
+
+//TODO: 서버와 맞추기
+const BASE_URL = "";
+
+class AxiosClient extends HttpClient {
+	private readonly client: AxiosInstance;
+
+	constructor() {
+		super();
+		const axiosInstance = axios.create({
+			baseURL: BASE_URL,
+			withCredentials: true,
+		});
+		this.client = axiosInstance;
+	}
+
+	async request<
+		ResponseBodyT = unknown,
+		RequestQueryT = unknown,
+		RequestBodyT = unknown,
+	>(
+		config: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT> {
+		try {
+			const requestConfig: AxiosRequestConfig<ResponseBodyT> = {
+				...this.client.defaults,
+				...config,
+				headers: { ...config.headers },
+			};
+			const response: AxiosResponse<ResponseBodyT> =
+				await this.client(requestConfig);
+			const { data } = response;
+			return data;
+		} catch (e) {
+			if (!axios.isAxiosError(e)) {
+				throw this.errorHandler(
+					new HttpError({
+						message: "Something went wrong!",
+						response: { status: 500, data: undefined },
+					}),
+				);
+			}
+
+			const httpErrorResponse: HttpResponse = {
+				data: e.response?.data,
+				status: e.response?.status ?? 500,
+			};
+
+			throw this.errorHandler(
+				new HttpError({
+					message: e.message,
+					response: e.response ? httpErrorResponse : undefined,
+				}),
+			);
+		}
+	}
+
+	public errorHandler(
+		e: HttpError<unknown>,
+	): HttpError<unknown> | Promise<HttpError<unknown>> {
+		//TODO: 서버와 코드 맞추고 핸들링 로직 추가
+		if (e.response?.status === 403) {
+			alert("권한 없어용");
+		}
+		return e;
+	}
+}
+
+export default AxiosClient;
+export const Api = new AxiosClient();

--- a/src/api/dto/_exampleDto.ts
+++ b/src/api/dto/_exampleDto.ts
@@ -1,0 +1,8 @@
+export type ExampleDto = {
+	id: number;
+	name: string;
+};
+
+export type ExampleCrateDto = {
+	name: string;
+};

--- a/src/api/dto/base.ts
+++ b/src/api/dto/base.ts
@@ -1,0 +1,13 @@
+import type { PaginationData } from "./pagination";
+
+// TODO: 서버와 맞추기
+export type BaseResponse<D = unknown> = {
+	code: string;
+	message: string;
+	status: string;
+	statusMessage: string;
+	data: D;
+};
+
+// TODO: 서버와 맞추기
+export type PaginationResponse<D = unknown> = BaseResponse<PaginationData<D>>;

--- a/src/api/dto/pagination.ts
+++ b/src/api/dto/pagination.ts
@@ -1,0 +1,11 @@
+// TODO: 서버와 맞추기
+export type PaginationData<D> = {
+	dataList: D[];
+	totalPages: number;
+};
+
+// TODO: 서버와 맞추기
+export type PaginationParams = {
+	page?: number;
+	size?: number;
+};

--- a/src/api/http-client/error.ts
+++ b/src/api/http-client/error.ts
@@ -1,0 +1,14 @@
+import type { HttpResponse } from "./types";
+
+export interface HttpErrorProps<ResponseBodyT = unknown> {
+	message: string;
+	response?: HttpResponse<ResponseBodyT>;
+}
+
+export class HttpError<ResponseBodyT = unknown> extends Error {
+	response?: HttpResponse<ResponseBodyT>;
+	constructor({ message, response }: HttpErrorProps<ResponseBodyT>) {
+		super(message);
+		this.response = response;
+	}
+}

--- a/src/api/http-client/index.ts
+++ b/src/api/http-client/index.ts
@@ -1,0 +1,89 @@
+import type { HttpError } from "./error";
+import type { HttpRequestConfig } from "./types";
+
+export * from "./types";
+
+export abstract class HttpClient {
+	abstract errorHandler(e: HttpError): Promise<HttpError> | HttpError;
+
+	abstract request<
+		ResponseBodyT = unknown,
+		RequestQueryT = unknown,
+		RequestBodyT = unknown,
+	>(
+		config: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT>;
+
+	get<ResponseBodyT = unknown, RequestQueryT = unknown, RequestBodyT = unknown>(
+		url: string,
+		config?: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT> {
+		return this.request<ResponseBodyT, RequestQueryT, RequestBodyT>({
+			...config,
+			url,
+			method: "GET",
+		});
+	}
+
+	delete<
+		ResponseBodyT = unknown,
+		RequestQueryT = unknown,
+		RequestBodyT = unknown,
+	>(
+		url: string,
+		config?: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT> {
+		return this.request<ResponseBodyT, RequestQueryT, RequestBodyT>({
+			...config,
+			url,
+			method: "DELETE",
+		});
+	}
+
+	post<
+		ResponseBodyT = unknown,
+		RequestQueryT = unknown,
+		RequestBodyT = unknown,
+	>(
+		url: string,
+		data?: RequestBodyT,
+		config?: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT> {
+		return this.request<ResponseBodyT, RequestQueryT, RequestBodyT>({
+			...config,
+			url,
+			data,
+			method: "POST",
+		});
+	}
+
+	put<ResponseBodyT = unknown, RequestQueryT = unknown, RequestBodyT = unknown>(
+		url: string,
+		data?: RequestBodyT,
+		config?: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT> {
+		return this.request<ResponseBodyT, RequestQueryT, RequestBodyT>({
+			...config,
+			url,
+			data,
+			method: "PUT",
+		});
+	}
+
+	patch<
+		ResponseBodyT = unknown,
+		RequestQueryT = unknown,
+		RequestBodyT = unknown,
+	>(
+		url: string,
+		data?: Partial<RequestBodyT>,
+		config?: HttpRequestConfig<RequestQueryT, RequestBodyT>,
+	): Promise<ResponseBodyT> {
+		return this.request<ResponseBodyT, RequestQueryT, Partial<RequestBodyT>>({
+			...config,
+			url,
+			data,
+			method: "PATCH",
+		});
+	}
+}

--- a/src/api/http-client/types.ts
+++ b/src/api/http-client/types.ts
@@ -1,0 +1,18 @@
+export interface HttpResponse<ResponseBodyT = unknown> {
+	status: number;
+	data: ResponseBodyT;
+}
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface HttpRequestConfig<
+	RequestQueryT = unknown,
+	RequestBodyT = unknown,
+> {
+	url?: string;
+	baseUrl?: string;
+	method?: HttpMethod;
+	data?: RequestBodyT;
+	params?: RequestQueryT;
+	headers?: Record<string, string | number | boolean>;
+}

--- a/src/api/requests/_exampleRequest.ts
+++ b/src/api/requests/_exampleRequest.ts
@@ -1,0 +1,19 @@
+import { Api } from "../axios-client";
+import type { ExampleCrateDto, ExampleDto } from "../dto/_exampleDto";
+import type { BaseResponse, PaginationResponse } from "../dto/base";
+import type { PaginationParams } from "../dto/pagination";
+
+export const getExample = () => {
+	return Api.get<BaseResponse<ExampleDto>>("/example");
+};
+
+export const getExampleList = (customPaginationParams: PaginationParams) => {
+	const paginationParams = { page: 0, size: 20, ...customPaginationParams };
+	return Api.get<PaginationResponse<ExampleDto>>("/example", {
+		params: paginationParams,
+	});
+};
+
+export const createExample = (data: ExampleCrateDto) => {
+	return Api.post<ExampleDto>("/example", data);
+};


### PR DESCRIPTION
## feature

- api client 추가합니다.
- 서버랑 정해야하는 부분은 임의로 넣어놨어요.

## 전하고픈 말

- axios interface와 무관한 http-client 추상 클래스를 두고, axios-client는 그걸 상속받아서 구체화하는 구조입니다~
- 그냥 api client 클래스 하나만 추가하면 되긴하는데, 다른 분이 이렇게 한걸 봐서 괜히 따라해보고 싶었어요. ㅎㅎ
- 원래는 AxiosClient를 request 함수까지만 구체화한 추상 클래스로 만들고, 그걸 또 상속받아서 각 서비스별로 구체화된 errorHandler를 갖는 ApiClient 클래스를 만들수도 있는데..... 그렇게까지 할 필욘 없을 것 같아서 AxiosClient에서 바로 인스턴스를 만들었습니다
